### PR TITLE
Update `mirage-crypto-rng-lwt`

### DIFF
--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -20,7 +20,8 @@ depends: [
   "base64" {>= "3.0.0"}
   "dune" {>= "3.0"}
   "alcotest" {>= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
   "mdx" {with-test}
   "asetmap" {with-test}
   "eio_main"

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -3,7 +3,7 @@ open Astring
 
 module Log = Capnp_rpc.Debug.Log
 
-let () = Mirage_crypto_rng_lwt.initialize ()
+let () = Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna)
 
 module CapTP = Vat_network.CapTP
 module Vat = Vat_network.Vat

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_unix)
  (public_name capnp-rpc-unix)
  (libraries eio.unix astring capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs
-   mirage-crypto-rng.lwt cmdliner cstruct extunix))
+   mirage-crypto-rng-lwt cmdliner cstruct extunix))


### PR DESCRIPTION
Breaking change in `mirage-crypto-rng` 0.11.0 moves the `.lwt` module to another package. This PR is required for
[ocurrent/clarke](https://github.com/ocurrent/clarke).